### PR TITLE
Added redirects to next.config.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,15 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  async redirects() {
+    return [
+      {
+        source: "/",
+        destination: "/listings",
+        permanent: false,
+      },
+      //add other redirects here as necessary
+    ];
+  },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
Nothing too fancy, catches '/' only at the moment.  Probably would be nice to catch anything non route matching in the future instead of generic 404 (v2 worries).

Documentation for reference and configuration
https://nextjs.org/docs/app/api-reference/next-config-js/redirects